### PR TITLE
Edit comments

### DIFF
--- a/src/Types/Controller.hs
+++ b/src/Types/Controller.hs
@@ -546,7 +546,7 @@ instance ( Monad m
     commit . pur . second $ \v -> v { commentField = "" }
     maybe (return ()) (newComment tid newId txt) (sessionId <$> session z)
 
-  handleOpenEdit c = pur (second (\v -> v { editCommentField = Just (c, "") } ) )
+  handleOpenEdit c = pur (\(z, v) -> (z, v { editCommentField = Just (c, fromMaybe "" $ commentText <$> M.lookup c (comments z)) }))
 
   handleCancelEdit = pur (second (\v -> v { editCommentField = Nothing } ) )
 

--- a/src/Types/Controller.hs
+++ b/src/Types/Controller.hs
@@ -40,8 +40,7 @@ import           Data.Proxy
 import qualified Data.Set as S
 import           Data.Text (Text, intercalate, split, reverse)
 import           Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import           Data.Time.Calendar (fromGregorian)
-import           Data.Time.Clock (UTCTime (..), secondsToDiffTime)
+import           Data.Time.Clock (UTCTime (..), getCurrentTime, secondsToDiffTime)
 import qualified Data.UUID as U
 import           Data.UUID.Next (nextUUID)
 import           GHC.Generics
@@ -480,15 +479,8 @@ newRelation r = saveChange (NewRelation r)
 deleteRelation :: ZettelEditor m => Relation -> SessionId -> m ()
 deleteRelation r = saveChange (DeleteRelation r)
 
--- TODO: get actual DiffTime (currently always returns midnight)
 getToday :: MonadJSM m => m UTCTime
-getToday = do
-  date  <- liftJSM $ eval ("new Date()" :: Text) >>= makeObject
-  day   <- round <$> liftJSM (((date # ("getDate" :: Text) :: [JSVal] -> JSM JSVal) $ []) >>= valToNumber)
-  month <- (1+) . round <$> liftJSM (((date # ("getMonth" :: Text) :: [JSVal] -> JSM JSVal) $ []) >>= valToNumber)
-  year  <- (1900+) . round <$> liftJSM (((date # ("getYear" :: Text) :: [JSVal] -> JSM JSVal) $ []) >>= valToNumber)
-  return (UTCTime (fromGregorian year month day) (secondsToDiffTime 0))
-
+getToday = liftIO getCurrentTime
 
 splitOn :: Eq a => a -> [a] -> Maybe ([a], [a])
 splitOn x xs = do

--- a/src/Types/Model.hs
+++ b/src/Types/Model.hs
@@ -212,7 +212,6 @@ threadComments z t = catMaybes $ flip M.lookup (comments z) <$> threadCommentIds
 commentText :: Comment -> Text
 commentText c = fromMaybe "" $ editText . fst <$> uncons (commentEdits c)
 
-
 commentEdited :: Comment -> Bool
 commentEdited c = case commentEdits c of
                     (_:_:_) -> True

--- a/src/Types/Model.hs
+++ b/src/Types/Model.hs
@@ -35,7 +35,7 @@ import qualified Data.ByteString.Base16 as Base16
 import           Data.ByteString.Lazy (fromStrict, toStrict)
 import           Data.Either.Extra (eitherToMaybe)
 import           Data.Function ((&))
-import           Data.List (concatMap, uncons, findIndex, dropWhile, takeWhile)
+import           Data.List (concatMap, uncons, findIndex, dropWhile, takeWhile, sortBy)
 import qualified Data.Map as M
 import           Data.Maybe (catMaybes, fromMaybe, maybeToList, isNothing)
 import           Data.Proxy
@@ -210,7 +210,7 @@ threadComments z t = catMaybes $ flip M.lookup (comments z) <$> threadCommentIds
 
 
 commentText :: Comment -> Text
-commentText c = fromMaybe "" $ editText . fst <$> uncons (commentEdits c)
+commentText c = fromMaybe "" $ editText . fst <$> uncons (sortBy (\e f -> compare (editCreated f) (editCreated e)) $ commentEdits c)
 
 commentEdited :: Comment -> Bool
 commentEdited c = case commentEdits c of

--- a/src/Types/Model.hs
+++ b/src/Types/Model.hs
@@ -220,7 +220,8 @@ commentEdited c = case commentEdits c of
 
 
 commentLastEdited :: Comment -> UTCTime
-commentLastEdited c = fromMaybe (UTCTime (fromGregorian 0 0 0) (secondsToDiffTime 0)) $ editCreated . fst <$> uncons (commentEdits c)
+commentLastEdited c = fromMaybe (UTCTime (fromGregorian 0 0 0) (secondsToDiffTime 0)) $ 
+  editCreated . fst <$> uncons (sortBy (\e f -> compare (editCreated f) (editCreated e)) $ commentEdits c)
 
 
 hash :: Text -> JSM PasswordHash

--- a/src/Types/ViewModel.hs
+++ b/src/Types/ViewModel.hs
@@ -138,3 +138,8 @@ getNewThreadTitle (_, i) cat = fromMaybe "" $ M.lookup (categoryId cat) (newThre
 
 setCommentField :: (Zettel, ThreadV) -> Text -> (Zettel, ThreadV)
 setCommentField (z, v) t = (z, v { commentField = t })
+
+setEditCommentField :: (Zettel, ThreadV) -> Text -> (Zettel, ThreadV)
+setEditCommentField (z, v) t = case editCommentField v of
+  (Just (i, u)) -> (z, v { editCommentField = Just (i, t) })
+  Nothing       -> (z, v)

--- a/src/View/Thread.hs
+++ b/src/View/Thread.hs
@@ -10,7 +10,8 @@ import qualified Data.Map as M
 import           Prelude hiding (div)
 import           Data.Maybe (catMaybes)
 import           Data.Text
-import           Data.Time.Calendar
+import           Data.Time.Clock (UTCTime)
+import           Data.Time.Format (formatTime, defaultTimeLocale, iso8601DateFormat)
 
 import           Shpadoinkle
 import           Shpadoinkle.Html
@@ -77,5 +78,5 @@ commentView c = div [class' "s11k-comment mb-2"] [
       <> ", " <> dateView (commentCreated c)
     , button [ class' "form-control btn", onClickE (handleOpenEdit $ commentId c)  ] [ text "Edit Comment" ] ] ]
 
-dateView :: Day -> Text
-dateView = pack . (\(y, m, d) -> show y <> "-" <> show m <> "-" <> show d) . toGregorian
+dateView :: UTCTime -> Text
+dateView = pack . (formatTime defaultTimeLocale (iso8601DateFormat (Just "%H:%M:%S"))) 

--- a/src/View/Thread.hs
+++ b/src/View/Thread.hs
@@ -74,8 +74,8 @@ commentView c = div [class' "s11k-comment mb-2"] [
   div [class' "s11k-comment-text mb-1"] [ text (commentText c) ],
   div [class' "s11k-comment-metadata"]
     [ strong [] . (:[]) . text $ "- " <> unUserId (commentAuthor c)
-      <> ", " <> dateView (commentCreated c) ],
-  button [ class' "form-control btn", onClickE (handleOpenEdit $ commentId c)  ] [ text "Edit Comment" ] ]
+      <> ", " <> dateView (commentCreated c)
+    , button [ class' "form-control btn", onClickE (handleOpenEdit $ commentId c)  ] [ text "Edit Comment" ] ] ]
 
 dateView :: Day -> Text
 dateView = pack . (\(y, m, d) -> show y <> "-" <> show m <> "-" <> show d) . toGregorian


### PR DESCRIPTION
Update all dates to UTC timestamps. Sort comment edits by timestamp so as to display text of the most recent edit.

Caveats:
* This includes info about when users, threads, etc are created. So these need to be changed in the db. 
* This requires the corresponding PR to the server repo.